### PR TITLE
refactor: remove database tool registration

### DIFF
--- a/src/tools/register-tools.ts
+++ b/src/tools/register-tools.ts
@@ -1,14 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Props } from "../types";
-import { registerDatabaseTools } from "./database-tools";
 
 /**
  * Register all MCP tools based on user permissions
  */
 export function registerAllTools(server: McpServer, env: Env, props: Props) {
-	// Register database tools
-	registerDatabaseTools(server, env, props);
-	
-	// Future tools can be registered here
-	// registerOtherTools(server, env, props);
+  // Future tools can be registered here
+  // registerOtherTools(server, env, props);
 }


### PR DESCRIPTION
## Summary
- drop registerDatabaseTools import and usage from register-tools

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_68ad94dfab54832abc1a3e05be77c61e