### PR TITLE
Restore worker startup and tool index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,49 @@
-// src/tools/index.ts
+import OAuthProvider from "@cloudflare/workers-oauth-provider";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpAgent } from "agents/mcp";
+import { GitHubHandler } from "./auth/github-handler";
+import { closeDb } from "./database/connection";
+import { registerAllTools } from "./tools/register-tools";
+import { Props } from "./types";
 
-export { default as get_quote } from "./get_quote";
-export { default as get_timeseries } from "./get_timeseries";
-export { default as get_news } from "./get_news";
-export { default as get_chart } from "./get_chart";
+export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
+        server = new McpServer({
+                name: "PostgreSQL Database MCP Server",
+                version: "1.0.0",
+        });
 
-// If you add optional services, uncomment or add these:
-// export { default as get_fundamentals } from "./get_fundamentals";
-// export { default as get_topnews } from "./get_topnews";
-// export { default as get_filings } from "./get_filings";
-// export { default as get_breakingviews } from "./get_breakingviews";
+        /**
+         * Cleanup database connections when Durable Object is shutting down
+         */
+        async cleanup(): Promise<void> {
+                try {
+                        await closeDb();
+                        console.log('Database connections closed successfully');
+                } catch (error) {
+                        console.error('Error during database cleanup:', error);
+                }
+        }
+
+        /**
+         * Durable Objects alarm handler - used for cleanup
+         */
+        async alarm(): Promise<void> {
+                await this.cleanup();
+        }
+
+        async init() {
+                // Register all tools
+                registerAllTools(this.server, this.env, this.props);
+        }
+}
+
+export default new OAuthProvider({
+        apiHandlers: {
+                '/sse': MyMCP.serveSSE('/sse') as any,
+                '/mcp': MyMCP.serve('/mcp') as any,
+        },
+        authorizeEndpoint: "/authorize",
+        clientRegistrationEndpoint: "/register",
+        defaultHandler: GitHubHandler as any,
+        tokenEndpoint: "/token",
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,10 @@
+export { default as get_quote } from "./get_quote";
+export { default as get_timeseries } from "./get_timeseries";
+export { default as get_news } from "./get_news";
+export { default as get_chart } from "./get_chart";
+
+// If you add optional services, uncomment or add these:
+// export { default as get_fundamentals } from "./get_fundamentals";
+// export { default as get_topnews } from "./get_topnews";
+// export { default as get_filings } from "./get_filings";
+// export { default as get_breakingviews } from "./get_breakingviews";


### PR DESCRIPTION
## Summary
- Restore worker startup logic and server registration in `src/index.ts`
- Move tool exports to `src/tools/index.ts`

## Testing
- `npm run test:run`
- `npm run type-check` *(fails: TS2352 conversion errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8e4af344832a82a4e40f05bef943