### PR TITLE
Add unit tests for RKD tools

### DIFF
--- a/tests/unit/tools/get_chart.test.ts
+++ b/tests/unit/tools/get_chart.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import getChart from '../../../src/tools/get_chart'
+
+const env = {
+  RKD_BASE_URL: 'https://rkd.example.com',
+  RKD_APP_ID: 'app',
+  RKD_USERNAME: 'user',
+  RKD_PASSWORD: 'pass',
+}
+
+describe('get_chart tool', () => {
+  it('forms correct request and processes response', async () => {
+    const tokenResponse = { CreateServiceToken_Response_1: { Token: 'test-token' } }
+    const apiResponse = { image: 'base64data' }
+
+    const fetchMock = fetch as any
+    fetchMock.mockResolvedValueOnce({ json: async () => tokenResponse })
+    fetchMock.mockResolvedValueOnce({ json: async () => apiResponse })
+
+    const result = await getChart.handler(
+      { ric: 'AAPL.O', chartType: 'Bar', period: '3M', width: 800, height: 600 },
+      env
+    )
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `${env.RKD_BASE_URL}/Charts/Charts.svc/REST/Charts_1/GetChart_2`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-Trkd-Auth-Token': 'test-token' }),
+      })
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body)
+    expect(body).toEqual({
+      GetChart_Request_2: {
+        Symbol: 'AAPL.O',
+        ChartType: 'Bar',
+        Period: '3M',
+        Width: 800,
+        Height: 600,
+      },
+    })
+
+    expect(result).toEqual(apiResponse)
+  })
+})
+

--- a/tests/unit/tools/get_news.test.ts
+++ b/tests/unit/tools/get_news.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import getNews from '../../../src/tools/get_news'
+
+const env = {
+  RKD_BASE_URL: 'https://rkd.example.com',
+  RKD_APP_ID: 'app',
+  RKD_USERNAME: 'user',
+  RKD_PASSWORD: 'pass',
+}
+
+describe('get_news tool', () => {
+  it('forms correct request and processes response', async () => {
+    const tokenResponse = { CreateServiceToken_Response_1: { Token: 'test-token' } }
+    const apiResponse = { headlines: [{ id: 1, text: 'News' }] }
+
+    const fetchMock = fetch as any
+    fetchMock.mockResolvedValueOnce({ json: async () => tokenResponse })
+    fetchMock.mockResolvedValueOnce({ json: async () => apiResponse })
+
+    const result = await getNews.handler(
+      { query: 'AAPL', maxCount: 10, start: '2023-01-01', end: '2023-01-31' },
+      env
+    )
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `${env.RKD_BASE_URL}/News/News.svc/REST/News_1/RetrieveHeadlineML_1`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-Trkd-Auth-Token': 'test-token' }),
+      })
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body)
+    expect(body).toEqual({
+      RetrieveHeadlineML_Request_1: {
+        Query: 'AAPL',
+        MaxCount: 10,
+        DateRange: { StartDate: '2023-01-01', EndDate: '2023-01-31' },
+      },
+    })
+
+    expect(result).toEqual(apiResponse)
+  })
+})
+

--- a/tests/unit/tools/get_quote.test.ts
+++ b/tests/unit/tools/get_quote.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import getQuote from '../../../src/tools/get_quote'
+
+const env = {
+  RKD_BASE_URL: 'https://rkd.example.com',
+  RKD_APP_ID: 'app',
+  RKD_USERNAME: 'user',
+  RKD_PASSWORD: 'pass',
+}
+
+describe('get_quote tool', () => {
+  it('forms correct request and processes response', async () => {
+    const tokenResponse = { CreateServiceToken_Response_1: { Token: 'test-token' } }
+    const apiResponse = { data: { price: 123.45 } }
+
+    const fetchMock = fetch as any
+    fetchMock.mockResolvedValueOnce({ json: async () => tokenResponse })
+    fetchMock.mockResolvedValueOnce({ json: async () => apiResponse })
+
+    const result = await getQuote.handler({ ric: 'AAPL.O', scope: 'All' }, env)
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `${env.RKD_BASE_URL}/Quotes/Quotes.svc/REST/Quotes_1/RetrieveItem_3`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-Trkd-Auth-Token': 'test-token' }),
+      })
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body)
+    expect(body).toEqual({
+      RetrieveItem_Request_3: {
+        TrimResponse: false,
+        ItemRequest: [
+          {
+            RequestKey: [{ Name: 'AAPL.O', NameType: 'RIC' }],
+            Scope: 'All',
+          },
+        ],
+      },
+    })
+
+    expect(result).toEqual(apiResponse)
+  })
+})
+

--- a/tests/unit/tools/get_timeseries.test.ts
+++ b/tests/unit/tools/get_timeseries.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import getTimeseries from '../../../src/tools/get_timeseries'
+
+const env = {
+  RKD_BASE_URL: 'https://rkd.example.com',
+  RKD_APP_ID: 'app',
+  RKD_USERNAME: 'user',
+  RKD_PASSWORD: 'pass',
+}
+
+describe('get_timeseries tool', () => {
+  it('forms correct request and processes response', async () => {
+    const tokenResponse = { CreateServiceToken_Response_1: { Token: 'test-token' } }
+    const apiResponse = { prices: [1, 2, 3] }
+
+    const fetchMock = fetch as any
+    fetchMock.mockResolvedValueOnce({ json: async () => tokenResponse })
+    fetchMock.mockResolvedValueOnce({ json: async () => apiResponse })
+
+    const result = await getTimeseries.handler(
+      { ric: 'AAPL.O', start: '2023-01-01', end: '2023-01-31', interval: 'Weekly' },
+      env
+    )
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `${env.RKD_BASE_URL}/TimeSeries/TimeSeries.svc/REST/TimeSeries_1/GetInterdayTimeSeries_5`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-Trkd-Auth-Token': 'test-token' }),
+      })
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body)
+    expect(body).toEqual({
+      GetInterdayTimeSeries_Request_5: {
+        Symbol: 'AAPL.O',
+        StartDate: '2023-01-01',
+        EndDate: '2023-01-31',
+        Interval: 'Weekly',
+      },
+    })
+
+    expect(result).toEqual(apiResponse)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add unit tests for get_quote, get_timeseries, get_chart, and get_news tools
- mock fetch to simulate RKD API responses
- verify correct request payloads and response handling

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68ad9ebeee20832abd856e32e04ae231