### PR TITLE
feat: add RKD env typing and error handling

### DIFF
--- a/tests/unit/tools/get_chart.test.ts
+++ b/tests/unit/tools/get_chart.test.ts
@@ -13,9 +13,9 @@ describe('get_chart tool', () => {
     const tokenResponse = { CreateServiceToken_Response_1: { Token: 'test-token' } }
     const apiResponse = { image: 'base64data' }
 
-    const fetchMock = fetch as any
-    fetchMock.mockResolvedValueOnce({ json: async () => tokenResponse })
-    fetchMock.mockResolvedValueOnce({ json: async () => apiResponse })
+      const fetchMock = fetch as any
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => tokenResponse })
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => apiResponse })
 
     const result = await getChart.handler(
       { ric: 'AAPL.O', chartType: 'Bar', period: '3M', width: 800, height: 600 },

--- a/tests/unit/tools/get_news.test.ts
+++ b/tests/unit/tools/get_news.test.ts
@@ -13,9 +13,9 @@ describe('get_news tool', () => {
     const tokenResponse = { CreateServiceToken_Response_1: { Token: 'test-token' } }
     const apiResponse = { headlines: [{ id: 1, text: 'News' }] }
 
-    const fetchMock = fetch as any
-    fetchMock.mockResolvedValueOnce({ json: async () => tokenResponse })
-    fetchMock.mockResolvedValueOnce({ json: async () => apiResponse })
+      const fetchMock = fetch as any
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => tokenResponse })
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => apiResponse })
 
     const result = await getNews.handler(
       { query: 'AAPL', maxCount: 10, start: '2023-01-01', end: '2023-01-31' },

--- a/tests/unit/tools/get_quote.test.ts
+++ b/tests/unit/tools/get_quote.test.ts
@@ -13,9 +13,9 @@ describe('get_quote tool', () => {
     const tokenResponse = { CreateServiceToken_Response_1: { Token: 'test-token' } }
     const apiResponse = { data: { price: 123.45 } }
 
-    const fetchMock = fetch as any
-    fetchMock.mockResolvedValueOnce({ json: async () => tokenResponse })
-    fetchMock.mockResolvedValueOnce({ json: async () => apiResponse })
+      const fetchMock = fetch as any
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => tokenResponse })
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => apiResponse })
 
     const result = await getQuote.handler({ ric: 'AAPL.O', scope: 'All' }, env)
 

--- a/tests/unit/tools/get_timeseries.test.ts
+++ b/tests/unit/tools/get_timeseries.test.ts
@@ -13,9 +13,9 @@ describe('get_timeseries tool', () => {
     const tokenResponse = { CreateServiceToken_Response_1: { Token: 'test-token' } }
     const apiResponse = { prices: [1, 2, 3] }
 
-    const fetchMock = fetch as any
-    fetchMock.mockResolvedValueOnce({ json: async () => tokenResponse })
-    fetchMock.mockResolvedValueOnce({ json: async () => apiResponse })
+      const fetchMock = fetch as any
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => tokenResponse })
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => apiResponse })
 
     const result = await getTimeseries.handler(
       { ric: 'AAPL.O', start: '2023-01-01', end: '2023-01-31', interval: 'Weekly' },


### PR DESCRIPTION
## Summary
- define Env interface for RKD credentials
- add error handling for token/service calls and use Env type
- adjust unit tests for HTTP status checks

## Testing
- `npm test`
- `npm run type-check` *(fails: Parameter 'input' implicitly has an 'any' type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9fad8228832ab204864d85b623fb