### PR TITLE
Register MCP tools dynamically

### DIFF
--- a/src/tools/register-tools.ts
+++ b/src/tools/register-tools.ts
@@ -1,10 +1,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Props } from "../types";
+import * as tools from "./index";
 
 /**
  * Register all MCP tools based on user permissions
  */
 export function registerAllTools(server: McpServer, env: Env, props: Props) {
-  // Future tools can be registered here
-  // registerOtherTools(server, env, props);
+  for (const tool of Object.values(tools) as any[]) {
+    const { name, handler, ...config } = tool as any;
+    server.registerTool(name, config, (input) => handler(input, env));
+  }
 }


### PR DESCRIPTION
## Summary
- Import all tool modules and register them automatically
- Centralized registration using `server.registerTool`

## Testing
- `npm test -- --run`
- `npm run type-check` *(fails: Parameter 'input' implicitly has an 'any' type, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ada2583554832a9f79d8a0ddfe83c3