### PR TITLE
Wrap RKD tool responses in MCP response helpers

### DIFF
--- a/src/tools/get_chart.ts
+++ b/src/tools/get_chart.ts
@@ -1,4 +1,5 @@
-import { callRkdService } from "../rkdClient";
+import { callRkdService, type Env } from "../rkdClient";
+import { createSuccessResponse, createErrorResponse } from "../types";
 export default {
   name: "get_chart",
   description: "Get a chart image for a security",
@@ -13,7 +14,7 @@ export default {
     },
     required: ["ric"],
   },
-  handler: async (input, env) => {
+  handler: async (input: any, env: Env) => {
     const body = {
       GetChart_Request_2: {
         Symbol: input.ric,
@@ -23,10 +24,19 @@ export default {
         Height: input.height || 400,
       },
     };
-    return callRkdService(
-      env,
-      "/Charts/Charts.svc/REST/Charts_1/GetChart_2",
-      body
-    );
+
+    try {
+      const data = await callRkdService(
+        env,
+        "/Charts/Charts.svc/REST/Charts_1/GetChart_2",
+        body
+      );
+      return createSuccessResponse("Retrieved chart data", data);
+    } catch (error) {
+      return createErrorResponse(
+        "Failed to retrieve chart data",
+        error instanceof Error ? { message: error.message } : error
+      );
+    }
   },
 };

--- a/src/tools/get_news.ts
+++ b/src/tools/get_news.ts
@@ -1,4 +1,5 @@
-import { callRkdService } from "../rkdClient";
+import { callRkdService, type Env } from "../rkdClient";
+import { createSuccessResponse, createErrorResponse } from "../types";
 export default {
   name: "get_news",
   description: "Retrieve news headlines",
@@ -12,7 +13,7 @@ export default {
     },
     required: ["query"],
   },
-  handler: async (input, env) => {
+  handler: async (input: any, env: Env) => {
     const body = {
       RetrieveHeadlineML_Request_1: {
         Query: input.query,
@@ -22,10 +23,19 @@ export default {
           : {}),
       },
     };
-    return callRkdService(
-      env,
-      "/News/News.svc/REST/News_1/RetrieveHeadlineML_1",
-      body
-    );
+
+    try {
+      const data = await callRkdService(
+        env,
+        "/News/News.svc/REST/News_1/RetrieveHeadlineML_1",
+        body
+      );
+      return createSuccessResponse("Retrieved news headlines", data);
+    } catch (error) {
+      return createErrorResponse(
+        "Failed to retrieve news headlines",
+        error instanceof Error ? { message: error.message } : error
+      );
+    }
   },
 };

--- a/src/tools/get_quote.ts
+++ b/src/tools/get_quote.ts
@@ -1,4 +1,5 @@
-import { callRkdService } from "../rkdClient";
+import { callRkdService, type Env } from "../rkdClient";
+import { createSuccessResponse, createErrorResponse } from "../types";
 export default {
   name: "get_quote",
   description: "Get a real‑time quote for a security",
@@ -7,7 +8,7 @@ export default {
     properties: { ric: { type: "string" }, scope: { type: "string" } },
     required: ["ric"],
   },
-  handler: async (input, env) => {
+  handler: async (input: any, env: Env) => {
     const body = {
       RetrieveItem_Request_3: {
         TrimResponse: false,
@@ -19,10 +20,19 @@ export default {
         ],
       },
     };
-    return callRkdService(
-      env,
-      "/Quotes/Quotes.svc/REST/Quotes_1/RetrieveItem_3",
-      body
-    );
+
+    try {
+      const data = await callRkdService(
+        env,
+        "/Quotes/Quotes.svc/REST/Quotes_1/RetrieveItem_3",
+        body
+      );
+      return createSuccessResponse("Retrieved quote", data);
+    } catch (error) {
+      return createErrorResponse(
+        "Failed to retrieve quote",
+        error instanceof Error ? { message: error.message } : error
+      );
+    }
   },
 };

--- a/src/tools/get_timeseries.ts
+++ b/src/tools/get_timeseries.ts
@@ -1,4 +1,5 @@
-import { callRkdService } from "../rkdClient";
+import { callRkdService, type Env } from "../rkdClient";
+import { createSuccessResponse, createErrorResponse } from "../types";
 export default {
   name: "get_timeseries",
   description: "Get historical price data",
@@ -12,7 +13,7 @@ export default {
     },
     required: ["ric","start","end"],
   },
-  handler: async (input, env) => {
+  handler: async (input: any, env: Env) => {
     const body = {
       GetInterdayTimeSeries_Request_5: {
         Symbol: input.ric,
@@ -21,10 +22,19 @@ export default {
         Interval: input.interval || "Daily",
       },
     };
-    return callRkdService(
-      env,
-      "/TimeSeries/TimeSeries.svc/REST/TimeSeries_1/GetInterdayTimeSeries_5",
-      body
-    );
+
+    try {
+      const data = await callRkdService(
+        env,
+        "/TimeSeries/TimeSeries.svc/REST/TimeSeries_1/GetInterdayTimeSeries_5",
+        body
+      );
+      return createSuccessResponse("Retrieved time series data", data);
+    } catch (error) {
+      return createErrorResponse(
+        "Failed to retrieve time series data",
+        error instanceof Error ? { message: error.message } : error
+      );
+    }
   },
 };

--- a/tests/unit/tools/get_chart.test.ts
+++ b/tests/unit/tools/get_chart.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import getChart from '../../../src/tools/get_chart'
+import { createSuccessResponse } from '../../../src/types'
 
 const env = {
   RKD_BASE_URL: 'https://rkd.example.com',
@@ -42,7 +43,9 @@ describe('get_chart tool', () => {
       },
     })
 
-    expect(result).toEqual(apiResponse)
+    expect(result).toEqual(
+      createSuccessResponse('Retrieved chart data', apiResponse)
+    )
   })
 })
 

--- a/tests/unit/tools/get_news.test.ts
+++ b/tests/unit/tools/get_news.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import getNews from '../../../src/tools/get_news'
+import { createSuccessResponse } from '../../../src/types'
 
 const env = {
   RKD_BASE_URL: 'https://rkd.example.com',
@@ -40,7 +41,9 @@ describe('get_news tool', () => {
       },
     })
 
-    expect(result).toEqual(apiResponse)
+    expect(result).toEqual(
+      createSuccessResponse('Retrieved news headlines', apiResponse)
+    )
   })
 })
 

--- a/tests/unit/tools/get_quote.test.ts
+++ b/tests/unit/tools/get_quote.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import getQuote from '../../../src/tools/get_quote'
+import { createSuccessResponse } from '../../../src/types'
 
 const env = {
   RKD_BASE_URL: 'https://rkd.example.com',
@@ -41,7 +42,9 @@ describe('get_quote tool', () => {
       },
     })
 
-    expect(result).toEqual(apiResponse)
+    expect(result).toEqual(
+      createSuccessResponse('Retrieved quote', apiResponse)
+    )
   })
 })
 

--- a/tests/unit/tools/get_timeseries.test.ts
+++ b/tests/unit/tools/get_timeseries.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import getTimeseries from '../../../src/tools/get_timeseries'
+import { createSuccessResponse } from '../../../src/types'
 
 const env = {
   RKD_BASE_URL: 'https://rkd.example.com',
@@ -41,7 +42,9 @@ describe('get_timeseries tool', () => {
       },
     })
 
-    expect(result).toEqual(apiResponse)
+    expect(result).toEqual(
+      createSuccessResponse('Retrieved time series data', apiResponse)
+    )
   })
 })
 


### PR DESCRIPTION
## Summary
- wrap RKD tool handlers in `createSuccessResponse`/`createErrorResponse`
- adjust unit tests to expect standardized MCP responses

## Testing
- `npm test`
- `npm run type-check` *(fails: Property 'crypto' does not exist on type 'typeof globalThis'; Type 'Mock<...>' is not assignable to type)*

------
https://chatgpt.com/codex/tasks/task_e_68adb4a982ac832abd994c1dd5dd6513