### PR TITLE
refactor: simplify tool registration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 
         async init() {
                 // Register all tools
-                registerAllTools(this.server, this.env, this.props);
+                registerAllTools(this.server, this.env);
         }
 }
 

--- a/src/index_sentry.ts
+++ b/src/index_sentry.ts
@@ -31,7 +31,7 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 		}
 
                 // Register all tools
-                registerAllTools(this.server, this.env, this.props);
+                registerAllTools(this.server, this.env);
         }
 }
 

--- a/src/tools/register-tools.ts
+++ b/src/tools/register-tools.ts
@@ -1,11 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { Props } from "../types";
 import * as tools from "./index";
 
 /**
- * Register all MCP tools based on user permissions
+ * Register all MCP tools
  */
-export function registerAllTools(server: McpServer, env: Env, props: Props) {
+export function registerAllTools(server: McpServer, env: Env) {
   for (const tool of Object.values(tools) as any[]) {
     const { name, handler, ...config } = tool as any;
     server.registerTool(name, config, (input) => handler(input, env));

--- a/tests/mocks/crypto.mock.ts
+++ b/tests/mocks/crypto.mock.ts
@@ -40,8 +40,9 @@ export function resetCryptoMocks() {
 }
 
 // Apply mocks to global crypto object
-if (!global.crypto) {
-  Object.defineProperty(global, 'crypto', {
+const g = globalThis as any
+if (!g.crypto) {
+  Object.defineProperty(g, 'crypto', {
     value: {
       subtle: mockCryptoSubtle,
       getRandomValues: mockGetRandomValues,
@@ -49,6 +50,6 @@ if (!global.crypto) {
     writable: true,
   })
 } else {
-  global.crypto.subtle = mockCryptoSubtle
-  global.crypto.getRandomValues = mockGetRandomValues
+  g.crypto.subtle = mockCryptoSubtle
+  g.crypto.getRandomValues = mockGetRandomValues
 }

--- a/tests/mocks/github.mock.ts
+++ b/tests/mocks/github.mock.ts
@@ -34,7 +34,7 @@ export function resetGitHubMocks() {
 
 // Mock fetch for GitHub OAuth token exchange
 export function setupGitHubTokenExchange() {
-  global.fetch = vi.fn((url: string) => {
+  ;(globalThis as any).fetch = vi.fn((url: string) => {
     if (url.includes('github.com/login/oauth/access_token')) {
       return Promise.resolve({
         ok: true,
@@ -46,7 +46,7 @@ export function setupGitHubTokenExchange() {
 }
 
 export function setupGitHubTokenExchangeError() {
-  global.fetch = vi.fn((url: string) => {
+  ;(globalThis as any).fetch = vi.fn((url: string) => {
     if (url.includes('github.com/login/oauth/access_token')) {
       return Promise.resolve({
         ok: false,


### PR DESCRIPTION
## Summary
- refactor `registerAllTools` to accept only server and env
- update entrypoints to use new signature
- clean up test mocks for type checking

## Testing
- `npm test -- --run`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68adb6838960832a89e242affbba2c53