### PR TITLE
Cache RKD token until near expiry

### DIFF
--- a/src/rkdClient.ts
+++ b/src/rkdClient.ts
@@ -5,7 +5,33 @@ export interface Env {
   RKD_PASSWORD: string;
 }
 
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0; // epoch ms
+
+function parseExpiration(response: any): number {
+  const now = Date.now();
+  const candidate =
+    response?.TokenExpiration || response?.TokenExpiry || response?.Expiration || response?.Expires || response?.TokenExpires;
+  if (typeof candidate === "string") {
+    const parsed = Date.parse(candidate);
+    if (!isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  const lifetime = response?.Lifetime ?? response?.ExpiresIn;
+  if (typeof lifetime === "number" && !isNaN(lifetime)) {
+    return now + lifetime * 1000;
+  }
+  // Fallback to 1 hour if expiry information missing
+  return now + 60 * 60 * 1000;
+}
+
 export async function getRkdToken(env: Env): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && tokenExpiresAt - now > 10 * 60 * 1000) {
+    return cachedToken;
+  }
+
   const payload = {
     CreateServiceToken_Request_1: {
       ApplicationID: env.RKD_APP_ID,
@@ -13,32 +39,29 @@ export async function getRkdToken(env: Env): Promise<string> {
       Password: env.RKD_PASSWORD,
     },
   };
-  const res = await fetch(
-    `${env.RKD_BASE_URL}/TokenManagement/TokenManagement.svc/REST/Anonymous/TokenManagement_1/CreateServiceToken_1`,
-    {
-      method: "POST",
-      headers: { "content-type": "application/json;charset=utf-8" },
-      body: JSON.stringify(payload),
-    }
-  );
+  const res = await fetch(`${env.RKD_BASE_URL}/TokenManagement/TokenManagement.svc/REST/Anonymous/TokenManagement_1/CreateServiceToken_1`, {
+    method: "POST",
+    headers: { "content-type": "application/json;charset=utf-8" },
+    body: JSON.stringify(payload),
+  });
 
   if (!res.ok) {
     throw new Error(`Token request failed with status ${res.status}`);
   }
 
   const json = (await res.json()) as any;
-  const token = json?.CreateServiceToken_Response_1?.Token;
+  const response = json?.CreateServiceToken_Response_1;
+  const token = response?.Token;
   if (!token) {
     throw new Error("Token field missing in response");
   }
+
+  cachedToken = token;
+  tokenExpiresAt = parseExpiration(response);
   return token;
 }
 
-export async function callRkdService(
-  env: Env,
-  path: string,
-  body: object
-): Promise<any> {
+export async function callRkdService(env: Env, path: string, body: object): Promise<any> {
   const token = await getRkdToken(env);
   const res = await fetch(`${env.RKD_BASE_URL}${path}`, {
     method: "POST",

--- a/tests/unit/rkdClient.test.ts
+++ b/tests/unit/rkdClient.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+
+const env = {
+  RKD_BASE_URL: "https://example.com",
+  RKD_APP_ID: "app",
+  RKD_USERNAME: "user",
+  RKD_PASSWORD: "pass",
+};
+
+describe("getRkdToken caching", () => {
+  it("uses cached token when not near expiry", async () => {
+    vi.resetModules();
+    const { getRkdToken } = await import("../../src/rkdClient");
+    const expires = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    (fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ CreateServiceToken_Response_1: { Token: "token-1", TokenExpiration: expires } }),
+    });
+
+    const t1 = await getRkdToken(env);
+    const t2 = await getRkdToken(env);
+
+    expect(t1).toBe("token-1");
+    expect(t2).toBe("token-1");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes token when near expiry", async () => {
+    vi.resetModules();
+    const { getRkdToken } = await import("../../src/rkdClient");
+    const expSoon = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    const expLater = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    (fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ CreateServiceToken_Response_1: { Token: "token-1", TokenExpiration: expSoon } }),
+    });
+    (fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ CreateServiceToken_Response_1: { Token: "token-2", TokenExpiration: expLater } }),
+    });
+
+    const t1 = await getRkdToken(env);
+    const t2 = await getRkdToken(env);
+
+    expect(t1).toBe("token-1");
+    expect(t2).toBe("token-2");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- cache RKD service token and track expiration
- refresh token only when less than 10 minutes remain
- add unit tests for token caching behavior

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68adb8d14b30832aa86eb78e01ecab6f